### PR TITLE
Fix typo in example for Square.from_str

### DIFF
--- a/bulletchess/__init__.pyi
+++ b/bulletchess/__init__.pyi
@@ -244,7 +244,7 @@ class Square:
         >>> Square.from_string("E1") == E1
         True
         >>> Square.from_string("a2") == A2
-        Tru
+        True
         """
         ...
 


### PR DESCRIPTION
Changed "Tru" to "True" in line 247.